### PR TITLE
Add org-level documentation.

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,9 @@
+# Support for GitHub Pages Themes
+Hello there! While we do our best to respond to issues and PRs in this organization, you may find answers faster using one of the following resources:
+
+- [support.github.com](https://support.github.com/)
+  - The search on this page indexes several places in the GitHub Universe, so it's a great place to start looking for docs or community discussions
+- If you can't find any docs, feel free to ask your question in the GitHub Pages topic on [github.community](https://github.community/c/github-pages/31)
+- If your question is specific to how Jekyll works, check out the [Jekyll Resources Page](https://jekyllrb.com/resources/)
+
+If your issue is specific to one of the themes hosted in this organization, you're in the right place, so ask away!


### PR DESCRIPTION
This PR adds an org-level `SUPPORT.md` doc with links to various resources for getting help with Jekyll themes. The goal is to provide links to places where their questions might already be answered.

@pages-themes/maintainers 